### PR TITLE
Add a ClusterPolicy to prevent prometheus-operator CRD deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a ClusterPolicy to prevent prometheus-operator CRD deletion.
+
 ## [11.0.1] - 2024-07-18
 
 ### Added

--- a/helm/prometheus-operator-crd/templates/clusterpolicy-prevent-crd-deletion.yaml
+++ b/helm/prometheus-operator-crd/templates/clusterpolicy-prevent-crd-deletion.yaml
@@ -1,0 +1,29 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    policies.kyverno.io/title: Prevent Prometheus Operator CRDs deletion
+    policies.kyverno.io/subject: CRD
+  name: prevent-prometheus-operator-crd-deletion
+spec:
+  admission: true
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - CustomResourceDefinition
+          names:
+          - "*.monitoring.coreos.com"
+    name: prevent-prometheus-operator-crd-deletion
+    validate:
+      message: "This resource is preventing prometheus-operator CRDs deletion."
+      deny:
+        conditions:
+          any:
+            - key: {{`"{{request.operation || 'BACKGROUND'}}"`}}
+              operator: AnyIn
+              value:
+              - DELETE
+  validationFailureAction: Enforce


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/31155

⚠️ The next `prometheus-operator-crd` release will be embedded in the next `observability-bundle` release which will be use in release >= v29 where we might make the `observability-bundle` depending on `kyverno-crds` app.


