### PR TITLE
fix: fix ABS override_app_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
           app_catalog_test: default-test-catalog
           ct_config: ".circleci/ct-config.yaml"
           chart: prometheus-operator-crd
+          override_app_version: false
           filters:
             tags:
               only: /^v.*/
@@ -25,7 +26,7 @@ workflows:
           app_catalog_test: giantswarm-test-catalog
           ct_config: ".circleci/ct-config.yaml"
           chart: prometheus-operator-crd
+          override_app_version: false
           filters:
             tags:
               only: /^v.*/
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix ABS config to not override AppVersion in Chart.yaml
+
 ## [21.0.0] - 2026-05-22
 
 ### Changed


### PR DESCRIPTION
In recent versions, ABS and architect orb changed the default behaviour for overriding the AppVersion in Chart.yaml when building and pushing charts. Now the default is to override it.
This does not work for this chart, since we use an upstream image with a different version than the chart itself.