### PR TITLE
chore: remove `ct_config` from push-to-app-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ workflows:
           executor: app-build-suite
           app_catalog: default-catalog
           app_catalog_test: default-test-catalog
-          ct_config: ".circleci/ct-config.yaml"
           chart: prometheus-operator-crd
           override_app_version: false
           filters:
@@ -24,7 +23,6 @@ workflows:
           executor: app-build-suite
           app_catalog: giantswarm-catalog
           app_catalog_test: giantswarm-test-catalog
-          ct_config: ".circleci/ct-config.yaml"
           chart: prometheus-operator-crd
           override_app_version: false
           filters:


### PR DESCRIPTION
`ct_config` has been **ignored by architect-orb since v9.0.0 (when the `helm-lint` step it controlled was removed)** — passing it currently does nothing.

It is removed in the upcoming **architect-orb v10.0.0**. Because CircleCI fails config compilation on unknown job arguments, any repo still passing it will break the moment Renovate bumps the orb to v10. Merging this beforehand makes that bump a no-op for you.

No behaviour change: the parameter is already a no-op today.

Part of giantswarm/roadmap#4066